### PR TITLE
fix tcpservice

### DIFF
--- a/include/cbuf.h
+++ b/include/cbuf.h
@@ -1,12 +1,12 @@
-#ifndef CB_H
-#define CB_H
+#ifndef _CBUF_H_
+#define _CBUF_H_
 
 #include <stdlib.h>
 
 typedef size_t	cbsize_t;
 
 // Circular buffer object
-typedef struct cb_s
+typedef struct cbuf_s
 {
 	cbsize_t	size;		// buffer size
 	cbsize_t	read;		// index of oldest data
@@ -15,63 +15,63 @@ typedef struct cb_s
 	char*		buf;		// data buffer
 	char		empty;		// no data
 	char		allread;	// ((read == unread) == all is swallowed)
-} cb_t;
+} cbuf_t;
 
 // GIVE log2() of desired size
-#define CB_INIT(userbuf,sizelog2)	{ .size = 1 << (sizelog2), .buf = (userbuf), .write = 0, .read = 0, .unread = 0, .empty = 1, .allread = 1, }
+#define CBUF_INIT(userbuf,sizelog2)	{ .size = 1 << (sizelog2), .buf = (userbuf), .write = 0, .read = 0, .unread = 0, .empty = 1, .allread = 1, }
 
 //        read              unread                      write
 //  ________|_________________|___________________________|_________________
 // |eeeeeeee.rrrrrrrrrrrrrrrrr.uuuuuuuuuuuuuuuuuuuuuuuuuuu.eeeeeeeeeeeeeeeee|
 //  \                               buffer                                 /
-// r: data are given to user with cb_read_ptr(), will be freed with cb_ack()
-// u: unread data, can be read with cb_read() or pointed with cb_read_ptr()
-// e: empty space, filled with cb_write() or pointed to by cb_write_ptr()
+// r: data are given to user with cbuf_read_ptr(), will be freed with cbuf_ack()
+// u: unread data, can be read with cbuf_read() or pointed with cbuf_read_ptr()
+// e: empty space, filled with cbuf_write() or pointed to by cbuf_write_ptr()
 // for *_ptr(): returned len is desired_len truncated to buffer's border
-// so use cb_all_is_read() to check whether more data is readable
-// and cb_is_full() to check whether more data is writable
+// so use cbuf_all_is_read() to check whether more data is readable
+// and cbuf_is_full() to check whether more data is writable
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-// DO NOT MIX cb_read() and cb_read_ptr()+cb_ack() (cb_write*() can be mixed)
+// DO NOT MIX cbuf_read() and cbuf_read_ptr()+cbuf_ack() (cbuf_write*() can be mixed)
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 ///////////////////////////////////////////////////////////
 // macro always available
 
-// cb_is_empty() can be false while cb_all_is_read is true when using cb_read_ptr()
-// cb_is_empty()=cb_all_is_read() when using cb_read()
-#define cb_is_empty(cb) 		((cb)->empty)
-#define cb_all_is_read(cb)		((cb)->allread)
-#define cb_is_full(cb)  		(((cb)->read == (cb)->write) && !(cb)->empty)
-#define cb_flush(cb)			do { (cb)->read = (cb)->unread = (cb)->write = 0; (cb)->allread = (cb)->empty = 1; } while (0)
+// cbuf_is_empty() can be false while cbuf_all_is_read is true when using cbuf_read_ptr()
+// cbuf_is_empty()=cbuf_all_is_read() when using cbuf_read()
+#define cbuf_is_empty(cb) 		((cb)->empty)
+#define cbuf_all_is_read(cb)		((cb)->allread)
+#define cbuf_is_full(cb)  		(((cb)->read == (cb)->write) && !(cb)->empty)
+#define cbuf_flush(cb)			do { (cb)->read = (cb)->unread = (cb)->write = 0; (cb)->allread = (cb)->empty = 1; } while (0)
 
 // return available space for write
-size_t cb_write_available (cb_t* cb);
+size_t cbuf_write_available (cbuf_t* cb);
 
-void cb_init (cb_t* cb, char* userbuf, char sizelog2);
+void cbuf_init (cbuf_t* cb, char* userbuf, char sizelog2);
 
 ///////////////////////////////////////////////////////////
 // functions with copy
 
 // regular write/copy user data into buffer
 // return effective size copied <= desired_len
-cbsize_t	cb_write	(cb_t* cb, const char* data, cbsize_t desired_len);
+cbsize_t	cbuf_write	(cbuf_t* cb, const char* data, cbsize_t desired_len);
 
 // regular read/copy buffer into user data
 // return effctive size copied <= desired_len
-cbsize_t	cb_read		(cb_t* cb, char* buf, cbsize_t desired_len);
+cbsize_t	cbuf_read	(cbuf_t* cb, char* buf, cbsize_t desired_len);
 
 ///////////////////////////////////////////////////////////
 // functions with pointers
 
 // get buffer pointer to directly write into it
 // return available len <= desired_len
-cbsize_t	cb_write_ptr	(cb_t* cb, char** buf, cbsize_t desired_len);
+cbsize_t	cbuf_write_ptr	(cbuf_t* cb, char** buf, cbsize_t desired_len);
 
 // get buffer pointer to read
 // return available len <= desired_len
-cbsize_t	cb_read_ptr	(cb_t* cb, char** buf, cbsize_t desired_len);
+cbsize_t	cbuf_read_ptr	(cbuf_t* cb, char** buf, cbsize_t desired_len);
 
 // acknowledge read data (that can be discarded = overwritten)
-void		cb_ack		(cb_t* cb, cbsize_t len);
+void		cbuf_ack	(cbuf_t* cb, cbsize_t len);
 
-#endif
+#endif // _CBUF_H_

--- a/include/cbuftools.h
+++ b/include/cbuftools.h
@@ -3,7 +3,7 @@
 
 #include <stdarg.h>
 
-#include "cb.h"
+#include "cbuf.h"
 
 // was 128 but flash_scan help line is bigger:
 #define SPRINTBUFSIZE 256
@@ -11,7 +11,7 @@
 extern char sprintbuf [SPRINTBUFSIZE];
 
 void tooshortbuf (char* str, size_t size);
-int cb_printf (cb_t* cb, const char* fmt, ...) __attribute__ ((format (printf, 2, 3)));
-int cb_vprintf (cb_t* cb, const char* fmt, va_list ap);
+int cbuf_printf (cbuf_t* cb, const char* fmt, ...) __attribute__ ((format (printf, 2, 3)));
+int cbuf_vprintf (cbuf_t* cb, const char* fmt, va_list ap);
 
 #endif // _CBTOOLS_H_

--- a/include/tcpservice.h
+++ b/include/tcpservice.h
@@ -3,7 +3,7 @@
 
 #include <lwip/tcp.h>
 
-#include "cbtools.h"
+#include "cbuftools.h"
 
 typedef struct tcpservice_s tcpservice_t;
 
@@ -15,12 +15,12 @@ struct tcpservice_s
 
 	// circular buffer
 	char* sendbuf;
-	cb_t send_buffer;
+	cbuf_t send_buffer;
 
-	// listener args&callbacks
-	tcpservice_t* (*get_new_peer) (tcpservice_t* s);
+	// listener callbacks
+	tcpservice_t* (*cb_get_new_peer) (tcpservice_t* s);
 
-	// peer args&callbacks
+	// peer callbacks
 	void (*cb_established) (tcpservice_t* s);
 	void (*cb_closing) (tcpservice_t* s);
 	void (*cb_recv) (tcpservice_t* s, const char* data, size_t len);
@@ -35,8 +35,8 @@ struct tcpservice_s
 	.tcp = NULL,				\
 	.is_closing = false,			\
 	.sendbuf = NULL,			\
-	.send_buffer = CB_INIT(NULL, 0),	\
-	.get_new_peer = (cb_new_peer),		\
+	.send_buffer = CBUF_INIT(NULL, 0),	\
+	.cb_get_new_peer = (cb_new_peer),	\
 	.cb_established = NULL,			\
 	.cb_closing = NULL,			\
 	.cb_recv = NULL,			\

--- a/include/tcpservice.h
+++ b/include/tcpservice.h
@@ -13,11 +13,14 @@ struct tcpservice_s
 	struct tcp_pcb* tcp;
 	bool is_closing;
 
+	// circular buffer
+	char* sendbuf;
+	cb_t send_buffer;
+
 	// listener args&callbacks
 	tcpservice_t* (*get_new_peer) (tcpservice_t* s);
 
 	// peer args&callbacks
-	cb_t send_buffer;
 	void (*cb_established) (tcpservice_t* s);
 	void (*cb_closing) (tcpservice_t* s);
 	void (*cb_recv) (tcpservice_t* s, const char* data, size_t len);
@@ -26,22 +29,23 @@ struct tcpservice_s
 	void (*cb_cleanup) (tcpservice_t* s);
 };
 
-#define TCP_SERVICE_VOID()			\
+#define TCP_SERVICE_LISTENER(nameptr, cb_new_peer) \
 {						\
-	.name = NULL;				\
-	.tcp = NULL;				\
-	.is_closing = false;			\
+	.name = (nameptr),			\
+	.tcp = NULL,				\
+	.is_closing = false,			\
+	.sendbuf = NULL,			\
 	.send_buffer = CB_INIT(NULL, 0),	\
-	.cb_accepted = NULL,			\
+	.get_new_peer = (cb_new_peer),		\
+	.cb_established = NULL,			\
 	.cb_closing = NULL,			\
 	.cb_recv = NULL,			\
 	.cb_poll = NULL,			\
 	.cb_ack = NULL,				\
-	.cb_cleanup = NULL;			\
+	.cb_cleanup = NULL,			\
 }
 
 void tcp_log_err (err_t err);
-err_t cb_tcp_send (cb_t* cb, struct tcp_pcb *pcb);
 
 // install tcp service on port
 int tcp_service_install (const char* name, tcpservice_t* s, int port);

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,8 +5,8 @@ objects-y+=hostname.o
 objects-y+=env.o
 #objects-y+=strbuf.o
 #objects-y+=tcpbuf.o
-objects-$(CONFIG_SERVICE_TCP)+=cb.o
-objects-$(CONFIG_SERVICE_TCP)+=cbtools.o
+objects-$(CONFIG_SERVICE_TCP)+=cbuf.o
+objects-$(CONFIG_SERVICE_TCP)+=cbuftools.o
 objects-$(CONFIG_SERVICE_TCP)+=tcpservice.o
 objects-$(CONFIG_SERVICE_TELNET)+=svc_telnet.o
 

--- a/src/cbuf.c
+++ b/src/cbuf.c
@@ -1,15 +1,15 @@
 
 #include <string.h>
 
-#include "cb.h"
+#include "cbuf.h"
 
 #if 1
-#define do_flush(cb) cb_flush(cb)	// flushing when empty
+#define do_flush(cb) cbuf_flush(cb)	// flushing when empty
 #else
 #define do_flush(cb) do { } while (0)	// doing nothing
 #endif
 
-size_t cb_write_available (cb_t* cb)
+size_t cbuf_write_available (cbuf_t* cb)
 {
 	if (cb->read < cb->write || (cb->read == cb->write && cb->empty))
 		return (cb->size - cb->write) + cb->read;
@@ -17,7 +17,7 @@ size_t cb_write_available (cb_t* cb)
 		return cb->read - cb->write;
 }
 
-void cb_init (cb_t* cb, char* userbuf, char sizelog2)
+void cbuf_init (cbuf_t* cb, char* userbuf, char sizelog2)
 {
 	cb->size = ((cbsize_t)1) << sizelog2;
 	cb->buf = userbuf;
@@ -25,20 +25,20 @@ void cb_init (cb_t* cb, char* userbuf, char sizelog2)
 	cb->empty = cb->allread = 1;
 }
 
-static size_t cb_write_available_chunk (cb_t* cb)
+static size_t cbuf_write_available_chunk (cbuf_t* cb)
 {
 	return (cb->read < cb->write || (cb->read == cb->write && cb->empty))?
 		cb->size - cb->write:
 		cb->read - cb->write;
 }
 
-cbsize_t cb_write (cb_t* cb, const char* data, cbsize_t desired_len)
+cbsize_t cbuf_write (cbuf_t* cb, const char* data, cbsize_t desired_len)
 {
 	cbsize_t want = desired_len;
 	cbsize_t ret = 0;
-	while (want && !cb_is_full(cb))
+	while (want && !cbuf_is_full(cb))
 	{
-		cbsize_t writable_len = cb_write_available_chunk(cb);
+		cbsize_t writable_len = cbuf_write_available_chunk(cb);
 		cbsize_t chunk = (want > writable_len)? writable_len: want;
 		memcpy(cb->buf + cb->write, data + ret, chunk);
 		ret += chunk;
@@ -49,10 +49,10 @@ cbsize_t cb_write (cb_t* cb, const char* data, cbsize_t desired_len)
 	return ret;
 }
 
-cbsize_t cb_write_ptr (cb_t* cb, char** buf, cbsize_t desired_len)
+cbsize_t cbuf_write_ptr (cbuf_t* cb, char** buf, cbsize_t desired_len)
 {
 	*buf = cb->buf + cb->write;
-	cbsize_t writable_len = cb_write_available_chunk(cb);
+	cbsize_t writable_len = cbuf_write_available_chunk(cb);
 	if (desired_len > writable_len)
 		desired_len = writable_len;
 	if (desired_len)
@@ -65,14 +65,14 @@ cbsize_t cb_write_ptr (cb_t* cb, char** buf, cbsize_t desired_len)
 
 /////////////////////////////////////////////////////////////////////////////
 
-cbsize_t cb_read (cb_t* cb, char* data, cbsize_t desired_len)
+cbsize_t cbuf_read (cbuf_t* cb, char* data, cbsize_t desired_len)
 {
 	// cb->read must always be equal when using this function
-	// (do not use cb_*_ptr)
+	// (do not use cbuf_*_ptr)
 
 	cbsize_t want = desired_len;
 	cbsize_t ret = 0;
-	while (want && !cb_is_empty(cb))
+	while (want && !cbuf_is_empty(cb))
 	{
 		cbsize_t readable_len = cb->read >= cb->write?
 				cb->size - cb->read:
@@ -90,7 +90,7 @@ cbsize_t cb_read (cb_t* cb, char* data, cbsize_t desired_len)
 
 /////////////////////////////////////////////////////////////////////////////
 
-cbsize_t cb_read_ptr (cb_t* cb, char** buf, cbsize_t desired_len)
+cbsize_t cbuf_read_ptr (cbuf_t* cb, char** buf, cbsize_t desired_len)
 {
 	*buf = cb->buf + cb->unread;
 	cbsize_t readable_len = ((cb->unread > cb->write) || (cb->unread == cb->write && !cb->allread))?
@@ -103,7 +103,7 @@ cbsize_t cb_read_ptr (cb_t* cb, char** buf, cbsize_t desired_len)
 	return desired_len;
 }
 
-void cb_ack (cb_t* cb, cbsize_t len)
+void cbuf_ack (cbuf_t* cb, cbsize_t len)
 {
 	if (len)
 	{

--- a/src/cbuftools.c
+++ b/src/cbuftools.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "cbtools.h"
+#include "cbuftools.h"
 
 char sprintbuf [SPRINTBUFSIZE];
 
@@ -14,24 +14,24 @@ void tooshortbuf (char* str, size_t size)
 	strcpy(str + size + shift - (sizeof tooshortbuf - 1), tooshortbuf + shift);
 }
 
-int cb_printf (cb_t* cb, const char* fmt, ...)
+int cbuf_printf (cbuf_t* cb, const char* fmt, ...)
 {
 	int ret;
 	va_list ap;
 	va_start(ap, fmt);
-	ret = cb_vprintf(cb, fmt, ap);
+	ret = cbuf_vprintf(cb, fmt, ap);
 	va_end(ap);
 	return ret;
 }
 
-int cb_vprintf (cb_t* cb, const char* fmt, va_list ap)
+int cbuf_vprintf (cbuf_t* cb, const char* fmt, va_list ap)
 {
-	size_t cbavail = cb_write_available(cb);
+	size_t cbavail = cbuf_write_available(cb);
 	if (cbavail + 1 > SPRINTBUFSIZE)
 		cbavail = SPRINTBUFSIZE - 1;
 
 	if (vsnprintf(sprintbuf, cbavail + 1, fmt, ap) >= cbavail + 1)
 		tooshortbuf(sprintbuf, cbavail + 1);
 
-	return cb_write(cb, sprintbuf, strlen(sprintbuf));
+	return cbuf_write(cb, sprintbuf, strlen(sprintbuf));
 }

--- a/src/svc_telnet.c
+++ b/src/svc_telnet.c
@@ -77,7 +77,7 @@ static int telnet_printf (const char *fmt, ...)
 	va_list ap;
 	va_start(ap, fmt);
 	if (current_telnet && current_telnet->peer.tcp)
-		ret = cb_vprintf(&current_telnet->peer.send_buffer, fmt, ap);
+		ret = cbuf_vprintf(&current_telnet->peer.send_buffer, fmt, ap);
 	else
 	{
 		vsnprintf(sprintbuf, SPRINTBUFSIZE, fmt, ap);
@@ -102,8 +102,8 @@ static tcpservice_t* telnet_new_peer (tcpservice_t* s)
 	}
 	
 	ts->peer.name = "telnet";
-	cb_init(&ts->peer.send_buffer, ts->peer.sendbuf, TELNET_SEND_BUFFER_SIZE_LOG2_DEFAULT);
-	ts->peer.get_new_peer = NULL;
+	cbuf_init(&ts->peer.send_buffer, ts->peer.sendbuf, TELNET_SEND_BUFFER_SIZE_LOG2_DEFAULT);
+	ts->peer.cb_get_new_peer = NULL;
 	ts->peer.cb_established = telnet_established;
 	ts->peer.cb_closing = telnet_closing;
 	ts->peer.cb_recv = telnet_recv;
@@ -162,7 +162,7 @@ int sendopt (tcpservice_t* s, u8_t option, u8_t value)
 	tmp[1] = option;
 	tmp[2] = value;
 	tmp[3] = 0;
-	return cb_write(&s->send_buffer, tmp, 4) == 4? 0: -1;
+	return cbuf_write(&s->send_buffer, tmp, 4) == 4? 0: -1;
 }
 
 static void telnet_recv (tcpservice_t* s, const char* q, size_t len)

--- a/src/svc_telnet.c
+++ b/src/svc_telnet.c
@@ -1,4 +1,6 @@
 
+// TODO: include telnet_state_t in send_buffer so to remove the need of telnet_service_s 
+
 #define TELNET_IAC   255
 #define TELNET_WILL  251
 #define TELNET_WONT  252
@@ -38,7 +40,6 @@ typedef struct telnet_service_s
 {
 	tcpservice_t peer;	// tcp service - COMES FIRST HERE
 	telnet_state_t state;	// telnet state
-	char* send_buffer;	// circular buffer
 } telnet_service_t;
 
 #define TS(s)		((telnet_service_t*)(s))
@@ -58,21 +59,7 @@ static void telnet_cleanup (tcpservice_t* s);
 
 // tcp server only, takes no space
 // (the "socketserver" awaiting for incoming request only)
-// sizeof=64
-static tcpservice_t telnet_listener =
-{
-	.name = "telnet listener",
-	.tcp = NULL,
-	.is_closing = false,
-	.send_buffer = CB_INIT(NULL, 0),
-	.get_new_peer = telnet_new_peer,
-	.cb_established = NULL,
-	.cb_closing = NULL,
-	.cb_recv = NULL,
-	.cb_poll = NULL,
-	.cb_ack = NULL,
-	.cb_cleanup = NULL,
-};
+static tcpservice_t telnet_listener = TCP_SERVICE_LISTENER("telnet listener", telnet_new_peer);
 
 // the current talking telnet peer, which is a hack
 static telnet_service_t* current_telnet = NULL;
@@ -107,15 +94,15 @@ static tcpservice_t* telnet_new_peer (tcpservice_t* s)
 	telnet_service_t* ts = (telnet_service_t*)os_malloc(sizeof(telnet_service_t));
 	if (!ts)
 		return NULL;
-	ts->send_buffer = (char*)os_malloc(1 << (TELNET_SEND_BUFFER_SIZE_LOG2_DEFAULT));
-	if (!ts->send_buffer)
+	ts->peer.sendbuf = (char*)os_malloc(1 << (TELNET_SEND_BUFFER_SIZE_LOG2_DEFAULT));
+	if (!ts->peer.sendbuf)
 	{
 		os_free(ts);
 		return NULL;
 	}
 	
 	ts->peer.name = "telnet";
-	cb_init(&ts->peer.send_buffer, ts->send_buffer, TELNET_SEND_BUFFER_SIZE_LOG2_DEFAULT);
+	cb_init(&ts->peer.send_buffer, ts->peer.sendbuf, TELNET_SEND_BUFFER_SIZE_LOG2_DEFAULT);
 	ts->peer.get_new_peer = NULL;
 	ts->peer.cb_established = telnet_established;
 	ts->peer.cb_closing = telnet_closing;
@@ -130,18 +117,6 @@ static tcpservice_t* telnet_new_peer (tcpservice_t* s)
 	const char *tmp = env_get("telnet-drop");
 	if (tmp)
 		ts->state.max_idle = atoi(tmp);
-	
-#if 0
-checked - remove me
-	if ((void*)ts != (void*)&(ts->peer))
-	{
-		LOGSERIAL(LOG_ERR, "bad alignment :( %x %x", (void*)ts, (void*)&(ts->peer));
-		os_free(ts->send_buffer);
-		os_free(ts);
-		return NULL;
-	}
-#endif
-
 	return &ts->peer;
 }
 
@@ -164,8 +139,8 @@ static void telnet_closing (tcpservice_t* s)
 static void telnet_cleanup (tcpservice_t* s)
 {
 	telnet_service_t* ts = TS(s);
-	if (ts->send_buffer)
-		os_free(ts->send_buffer);
+	if (ts->peer.sendbuf)
+		os_free(ts->peer.sendbuf);
 	os_free(ts);
 }
 

--- a/src/tcpservice.c
+++ b/src/tcpservice.c
@@ -11,18 +11,23 @@ void tcp_log_err (err_t err)
 	LOGSERIAL(LOG_ERR, "TCP: Fatal error %d(%s)", (int)err, lwip_strerr(err));
 }
 
-err_t cb_tcp_send (cb_t* cb, struct tcp_pcb *pcb)
+// tcp_send() is static:
+// tcp_write() cannot be called by user's callbacks (it hangs lwip)
+// trigger write-from-circular-buffer
+static err_t cb_tcp_send (tcpservice_t* tcp)
 {
-	err_t err;
+	err_t err = ERR_OK;
 	char* data;
-	size_t sendsize = cb_read_ptr(cb, &data, tcp_sndbuf(pcb) /* = sendmax */);
+	
+	size_t sendsize = cb_read_ptr(&tcp->send_buffer, &data, tcp_sndbuf(tcp->tcp) /* = sendmax */);
 	if (   sendsize
-	    && ((err = tcp_write(pcb, data, sendsize, /*tcpflags=0=PUSH,NOCOPY*/0)) != ERR_OK))
+	    && (   (err = tcp_write(tcp->tcp, data, sendsize, /*tcpflags=0=PUSH,NOCOPY*/0)) != ERR_OK
+	        || (err = tcp_output(tcp->tcp)) != ERR_OK))
 	{
 		tcp_log_err(err);
-		return err;
 	}
-	return ERR_OK;
+
+	return err;
 }
 
 static err_t tcp_service_receive (void* svc, struct tcp_pcb *pcb, struct pbuf *pbuf, err_t err)
@@ -34,7 +39,7 @@ static err_t tcp_service_receive (void* svc, struct tcp_pcb *pcb, struct pbuf *p
 		tcp_recved(peer->tcp, pbuf->tot_len);
 		peer->cb_recv(peer, pbuf->payload, pbuf->tot_len);
 		pbuf_free(pbuf);
-		return cb_tcp_send(&peer->send_buffer, peer->tcp);
+		return cb_tcp_send(peer);
 	}
 	else
 	{
@@ -53,22 +58,25 @@ static bool tcp_service_check_shutdown (tcpservice_t* s)
 		s->tcp = NULL;
 		if (s->cb_cleanup)
 			s->cb_cleanup(s);
-		return 1;
+		return true;
 	}
-	return 0;
+	return false;
 }
 
 static err_t tcp_service_ack (void *svc, struct tcp_pcb *pcb, u16_t len)
 {
 	tcpservice_t* peer = (tcpservice_t*)svc;
 
-	cb_ack(&peer->send_buffer, len);
-	if (peer->cb_ack)
-		peer->cb_ack(peer);
+	if (len)
+	{
+		cb_ack(&peer->send_buffer, len);
+		if (peer->cb_ack)
+			peer->cb_ack(peer);
+	}
 	
 	return tcp_service_check_shutdown(peer)?
 		ERR_OK:
-		cb_tcp_send(&peer->send_buffer, peer->tcp);
+		cb_tcp_send(peer);
 }
 
 static void tcp_service_error (void* svc, err_t err)
@@ -86,7 +94,7 @@ static err_t tcp_service_poll (void* svc, struct tcp_pcb* pcb)
 		service->cb_poll(service);
 
 	// trigger send buffer if needed
-	tcp_service_ack(service, service->tcp, 0);
+	cb_tcp_send(service);
 		
 	return ERR_OK;
 }
@@ -101,6 +109,7 @@ static err_t tcp_service_incoming_peer (void* svc, struct tcp_pcb * peer_pcb, er
 	tcpservice_t* peer = listener->get_new_peer(listener);
 	if (!peer)
 		return ERR_MEM; //XXX handle this better
+
 	peer->tcp = peer_pcb;
 	peer->is_closing = 0;
 	
@@ -113,6 +122,12 @@ static err_t tcp_service_incoming_peer (void* svc, struct tcp_pcb * peer_pcb, er
 	// peer/tcp_pcb association
 	tcp_arg(peer->tcp, peer);
 	
+#if 0
+	SERIAL_PRINTF("%s: nagle=%d\n", peer->name, tcp_nagle_disabled(peer->tcp));
+	tcp_nagle_disable(peer->tcp);
+	SERIAL_PRINTF("%s: nagle=%d\n", peer->name, tcp_nagle_disabled(peer->tcp));
+#endif
+
 	// start fighting
 	if (peer->cb_established)
 		peer->cb_established(peer);


### PR DESCRIPTION
git log:
    fix tcpservice: tcp_output() was not called, so effective send was delayed
    also: move buffer pointer into the tcpservice structure (svc_telnet structure will then be optimized into buffer too)
    rename circular buffer functions, files and structures cb* to cbuf* to avoid confusion with callback "cb"
    move src/cbtest.c to src/contrib/cbuftest.c
