### PR TITLE
Handle ';' in command lines.

### DIFF
--- a/include/microrl.h
+++ b/include/microrl.h
@@ -82,8 +82,10 @@ typedef struct {
 #endif
 	char * prompt_str;                 // pointer to prompt string
 	char cmdline [_COMMAND_LINE_LEN];  // cmdline buffer
+	char *pcmdline;
 	int cmdlen;                        // last position in command line
 	int cursor;                        // input cursor
+	char *next;                        // If set, start parsing here ...
 	int (*execute) (int argc, const char * const * argv );            // ptr to 'execute' callback
 	const char ** (*get_completion) (int argc, const char * const * argv ); // ptr to 'completion' callback
 	void (*print) (const char *);                                     // ptr to 'print' callback

--- a/kcnf
+++ b/kcnf
@@ -97,6 +97,9 @@ bool "SHT21 humidity sensor"
 config CMD_I2C_BH1750
 bool "BH1750 light sensor"
 
+config CMD_I2C_SI7020
+bool "SI7020 Temperature/Humidity sensor"
+
 config CMD_I2C_PCF8591
 bool "PCF8591 8-bit ADC DAC"
 

--- a/src/main.c
+++ b/src/main.c
@@ -181,6 +181,20 @@ static void main_init_done(void)
 	    }
 	  }
 	}
+	/*
+	 * Check for $bootcmd after initializing wifi ...
+	 */
+	const char *cmd = env_get("bootcmd");
+	if (cmd!= NULL) {
+		int i=0;
+		console_printf("Running bootcmd: %s\r\n", cmd);
+		console_insert('\r');
+		console_insert('\n');
+		while(cmd[i] != '\0')
+			console_insert(cmd[i++]);
+		console_insert('\r');
+		console_insert('\n');
+	}
 }
 
 void user_init()


### PR DESCRIPTION
Supports ';' in the following ways:

arg;arg
arg; arg
arg ;arg
arg ; arg

e.g.:

frankenstein > gpio in 0;gpio in 0
GP0==1

GP0==1

frankenstein > gpio in 0 ; gpio in 0
GP0==1

GP0==1

frankenstein > gpio in 0; gpio in 0
GP0==1

GP0==1

frankenstein > gpio in 0 ;gpio in 0
GP0==1

GP0==1

frankenstein > gpio in 0 ;     gpio in 0
GP0==1

GP0==1


Also adds support for executing $bootcmd if it is set, a'la u-boot:

 === Press enter to activate this console === 
Running bootcmd: i2c init 5 2; i2c scan

frankenstein > i2c init 5 2; i2c scan
Init i2c bus on GPIO5:GPIO2 ok

Enumeration i2c bus...

Found device on 0x00. Unknown device (0).
Found device on 0x80. SHT21? HTU21? SI7020? 

