### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ All changes are made in ram. To save them to flash run
 
 Environment variables hold paramers for the firmware that are
 applied on boot or affect certain commands.
-All variables are described in [README.env](README.env). You can also store arbitary data 
+All variables are described in [README.env](README.env). You can also store arbitrary data 
 in environment variables. 
 
 


### PR DESCRIPTION
@nekromant, I've corrected a typographical error in the documentation of the [esp8266-frankenstein](https://github.com/nekromant/esp8266-frankenstein) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.